### PR TITLE
Remove the link to the cloud.gov proof of concept

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,10 +1,5 @@
 # ![OpenControl Logo](img/oclogo.png)
 
-# Compliance as Code
-The fastest way to understand OpenControl is to see it in action.
-The 18F group in the GSA use it to build the System Security Plan for Cloud.gov,
-which you can see at [https://compliance.cloud.gov](https://compliance.cloud.gov).
-
 ## Compliance Professionals: Start with Tools
  [Compliance Masonry](https://github.com/opencontrol/compliance-masonry)
 


### PR DESCRIPTION
Note: by mistake I initially made this change as a direct commit on master, so I reverted that and am now filing this as a PR. I've gotten used to working with repositories that have protected master branches. :)

I'd like to remove the compliance.cloud.gov example from the homepage, since that site is pretty outdated and I'm not sure when our cloud.gov team will be able to update it.