### PR TITLE
add Code of Conduct

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -7,6 +7,8 @@ primary:
     href: /members/
   - text: Event
     href: /event2016/
+  - text: Code of Conduct
+    href: /code-of-conduct/
   - text: GitHub
     href: https://github.com/opencontrol/opencontrol-website
     external: true

--- a/_pages/code-of-conduct.md
+++ b/_pages/code-of-conduct.md
@@ -4,19 +4,19 @@ title: Code of Conduct
 
 We are group of technologists, government staff, contractors and others in regulated fields passionately pursuing Compliance-as-Code.
 
-We are developing a cmmunity and tools at http://open-control.org necessary to align security assessments and authorizations with modern, continuous software development and delivery.
+We are developing a community and tools necessary to align security assessments and authorizations with modern, continuous software development and delivery.
 
-We extend to you an invitation to join our Slack provided you agree to the following terms.
+We extend to you an invitation to join our community, provided you agree to the following terms.
 
 ## Respectful and professional discourse
 
-At all times you will engage in conversations that are respectful of other Slack members -- and third parties -- and professional in tone. We are professionals pursing professional goals. Respect and professionalism includes civil conversation, allowing others opinions, and avoiding personal disparaging comments, and contributing usefully to the community topic: Compliance-as-Code.
+At all times you will engage in conversations that are respectful of other members -- and third parties -- and professional in tone. We are professionals pursing professional goals. Respect and professionalism includes civil conversation, allowing others opinions, and avoiding personal disparaging comments, and contributing usefully to the community topic: Compliance-as-Code.
 
 Always respect a designated moderator.
 
-## Stay on target topic of each channel
+## Stay on target topic
 
-No matter how many TIE fighters are at your back, stay on the target topic of each channel.
+No matter how many TIE fighters are at your back, stay on the target topic of each Slack channel, GitHub issue, etc.
 
 ## Encourage participation
 
@@ -28,9 +28,9 @@ It's fine to let others in the community know about professional events, positio
 
 It's also cool to share and celebrate accomplishments and support for community members in their achievement of some milestone, life-event, or other leveling-up. (It's also OK to professionally rally the community in support of community members.)
 
-It is not fine to spam channels with multiple announcements, multiple times each week.
+It is not fine to spam our communication channels with multiple announcements, multiple times each week.
 
-Promotions for things not related OpenControl and Compliance-as-Code is restricted to appropriately designated channels.
+Promotions for things not related OpenControl and Compliance-as-Code is restricted to appropriately designated Slack channels.
 
 ## Acceptance the organizers can update the conduct code
 
@@ -38,8 +38,8 @@ _This policy is a "living" document, and subject to refinement and expansion in 
 
 ## Respect for diversity
 
-The **OpenControl Slack** is fine place for everybody regardless of race, religion, gender, identity, sexual orientation, technical ability, or employment situation.
+OpenControl is a place for everybody regardless of race, religion, gender, identity, sexual orientation, technical ability, or employment situation.
 
 ## Getting help
 
-If you are experiencing technical problems or non technical problems (like harassment) contact Greg Elin (@gregelin) or another moderator.
+If you are experiencing technical problems or non technical problems (like harassment) contact Greg Elin (@gregelin) or another moderator on Slack.

--- a/_pages/code-of-conduct.md
+++ b/_pages/code-of-conduct.md
@@ -1,0 +1,45 @@
+---
+title: Code of Conduct
+---
+
+We are group of technologists, government staff, contractors and others in regulated fields passionately pursuing Compliance-as-Code.
+
+We are developing a cmmunity and tools at http://open-control.org necessary to align security assessments and authorizations with modern, continuous software development and delivery.
+
+We extend to you an invitation to join our Slack provided you agree to the following terms.
+
+## Respectful and professional discourse
+
+At all times you will engage in conversations that are respectful of other Slack members -- and third parties -- and professional in tone. We are professionals pursing professional goals. Respect and professionalism includes civil conversation, allowing others opinions, and avoiding personal disparaging comments, and contributing usefully to the community topic: Compliance-as-Code.
+
+Always respect a designated moderator.
+
+## Stay on target topic of each channel
+
+No matter how many TIE fighters are at your back, stay on the target topic of each channel.
+
+## Encourage participation
+
+Be biased toward conversation and participation. Be comfortable asking questions and providing answers.
+
+## Appropriate, minimal personal/business promotion
+
+It's fine to let others in the community know about professional events, positions, new software releases and other developments that are highly relevant to the OpenControl and Compliance-as-Code community.
+
+It's also cool to share and celebrate accomplishments and support for community members in their achievement of some milestone, life-event, or other leveling-up. (It's also OK to professionally rally the community in support of community members.)
+
+It is not fine to spam channels with multiple announcements, multiple times each week.
+
+Promotions for things not related OpenControl and Compliance-as-Code is restricted to appropriately designated channels.
+
+## Acceptance the organizers can update the conduct code
+
+_This policy is a "living" document, and subject to refinement and expansion in the future._
+
+## Respect for diversity
+
+The **OpenControl Slack** is fine place for everybody regardless of race, religion, gender, identity, sexual orientation, technical ability, or employment situation.
+
+## Getting help
+
+If you are experiencing technical problems or non technical problems (like harassment) contact Greg Elin (@gregelin) or another moderator.


### PR DESCRIPTION
Follow-up to https://github.com/opencontrol/discuss/issues/12. Required for [Netlify open source program](https://www.netlify.com/legal/open-source-policy/), but a good idea to have it somewhere more visible anyway.

Would rather get this in sooner than later and discuss edits in follow-up issues or pull requests, rather than those things being blockers to having it in place.